### PR TITLE
Fix the list of publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,9 @@
 
 # Publications
 
-<div class="csl-bib-body" style="line-height: 1.35; ">
-  <div class="csl-entry" style="clear: left; ">
-    <div class="csl-left-margin" style="float: left; padding-right: 0.5em;text-align: right; width: 1em;">[1]</div><div class="csl-right-inline" style="margin: 0 .4em 0 1.5em;">M. Henderson, A. J. W. Hilton, and R. M. J. Jothi, ‘Bounds Related to The Edge-List Chromatic and Total Chromatic Numbers of a Simple Graph’, <i>arXiv:2004.01848 [math]</i>, Nov. 2020, Accessed: Nov. 26, 2020. [Online]. Available: <a href="http://arxiv.org/abs/2004.01848">http://arxiv.org/abs/2004.01848</a></div>
-  </div>
+<div class="csl-bib-body" style="line-height: 1.35; margin-left: 2em; text-indent:-2em;">
+  <div class="csl-entry">Henderson, M., A. J. W. Hilton, and R. Mary Jeya Jothi. 2020. ‘Bounds Related to The Edge-List Chromatic and Total Chromatic Numbers of a Simple Graph’. <i>arXiv:2004.01848 [Math]</i>, November. <a href="http://arxiv.org/abs/2004.01848">http://arxiv.org/abs/2004.01848</a>.</div>
   <span class="Z3988" title="url_ver=Z39.88-2004&amp;ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fzotero.org%3A2&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=article&amp;rft.atitle=Bounds%20Related%20to%20The%20Edge-List%20Chromatic%20and%20Total%20Chromatic%20Numbers%20of%20a%20Simple%20Graph&amp;rft.jtitle=arXiv%3A2004.01848%20%5Bmath%5D&amp;rft.aufirst=M.&amp;rft.aulast=Henderson&amp;rft.au=M.%20Henderson&amp;rft.au=A.%20J.%20W.%20Hilton&amp;rft.au=R.%20Mary%20Jeya%20Jothi&amp;rft.date=2020-11-24"></span>
-  <div class="csl-entry" style="clear: left; ">
-    <div class="csl-left-margin" style="float: left; padding-right: 0.5em;text-align: right; width: 1em;">[2]</div><div class="csl-right-inline" style="margin: 0 .4em 0 1.5em;">M. J. Henderson and A. J. W. Hilton, ‘Completing an edge-colouring of K 2m with K r and independent edges precoloured’, <i>Journal of the London Mathematical Society. Second Series</i>, vol. 70, Dec. 2004, doi: <a href="https://doi.org/10.1112/S0024610704005526">10.1112/S0024610704005526</a>.</div>
-  </div>
+  <div class="csl-entry">Henderson, M. J., and A. J. W Hilton. 2004. ‘Completing an Edge-Colouring of K 2m with K r and Independent Edges Precoloured’. <i>Journal of the London Mathematical Society. Second Series</i> 70 (December). <a href="https://doi.org/10.1112/S0024610704005526">https://doi.org/10.1112/S0024610704005526</a>.</div>
   <span class="Z3988" title="url_ver=Z39.88-2004&amp;ctx_ver=Z39.88-2004&amp;rfr_id=info%3Asid%2Fzotero.org%3A2&amp;rft_id=info%3Adoi%2F10.1112%2FS0024610704005526&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.genre=article&amp;rft.atitle=Completing%20an%20edge-colouring%20of%20K%202m%20with%20K%20r%20and%20independent%20edges%20precoloured&amp;rft.jtitle=Journal%20of%20the%20London%20Mathematical%20Society.%20Second%20Series&amp;rft.volume=70&amp;rft.aufirst=M.%20J.&amp;rft.aulast=Henderson&amp;rft.au=M.%20J.%20Henderson&amp;rft.au=A.%20J.%20W%20Hilton&amp;rft.date=2004-12-01"></span>
 </div>


### PR DESCRIPTION
Using the IEEE style looked bad on Pages, so try Chicago instead.